### PR TITLE
Added saga state machine example

### DIFF
--- a/src/Tests/SagaStateMachineTests.Run.verified.txt
+++ b/src/Tests/SagaStateMachineTests.Run.verified.txt
@@ -1,0 +1,226 @@
+﻿{
+  harness: {
+    InactivityTask: {
+      Result: true,
+      Id: Id_1,
+      Status: RanToCompletion,
+      IsCompleted: true,
+      IsCompletedSuccessfully: true,
+      CreationOptions: RunContinuationsAsynchronously
+    },
+    Consumed: [
+      {
+        Received: SagaStateMachineTests.Start,
+        MessageId: Guid_1,
+        ConversationId: Guid_2,
+        DestinationAddress: Tests:SagaStateMachineTests+Start,
+        Message: {
+          CorrelationId: Guid_3
+        }
+      }
+    ],
+    Published: [
+      {
+        Published: SagaStateMachineTests.Start,
+        MessageId: Guid_1,
+        ConversationId: Guid_2,
+        DestinationAddress: Tests:SagaStateMachineTests+Start,
+        Message: {
+          CorrelationId: Guid_3
+        }
+      }
+    ],
+    Sent: [],
+    Scope: {},
+    EndpointNameFormatter: {
+      Separator: 
+    },
+    Bus: {
+      Topology: {
+        PublishTopology: {},
+        SendTopology: {}
+      }
+    },
+    TestTimeout: 00:00:30,
+    TestInactivityTimeout: 00:00:01.2000000,
+    InactivityToken: {
+      IsCancellationRequested: true,
+      CanBeCanceled: true,
+      WaitHandle: {
+        SafeWaitHandle: {}
+      }
+    },
+    CancellationToken: {
+      CanBeCanceled: true,
+      WaitHandle: {
+        SafeWaitHandle: {}
+      }
+    }
+  },
+  sagaHarness: {
+    Consumed: [
+      {
+        Received: SagaStateMachineTests.Start,
+        MessageId: Guid_1,
+        ConversationId: Guid_2,
+        DestinationAddress: Tests:SagaStateMachineTests+Start,
+        Message: {
+          CorrelationId: Guid_3
+        }
+      }
+    ],
+    Sagas: [
+      {
+        Saga: {
+          CorrelationId: Guid_3,
+          CurrentState: Final,
+          StartMessageReceived: true
+        },
+        ElementId: Guid_3
+      }
+    ],
+    Created: [
+      {
+        Saga: {
+          CorrelationId: Guid_3,
+          CurrentState: Final,
+          StartMessageReceived: true
+        },
+        ElementId: Guid_3
+      }
+    ],
+    StateMachine: {
+      StartEvent: {
+        Name: StartEvent
+      },
+      Started: {
+        Name: Started,
+        Enter: {
+          Name: Started.Enter
+        },
+        Leave: {
+          Name: Started.Leave
+        },
+        BeforeEnter: {
+          Name: Started.BeforeEnter
+        },
+        AfterLeave: {
+          Name: Started.AfterLeave
+        },
+        Events: []
+      },
+      Correlations: [
+        {
+          ConfigureConsumeTopology: true,
+          FilterFactory: {
+            Type: SagaFilterFactory<SagaStateMachineTests.ConsumerSaga, SagaStateMachineTests.Start>,
+            Target: MassTransitEventCorrelationConfigurator<SagaStateMachineTests.ConsumerSaga, SagaStateMachineTests.Start>.<>c,
+            Method: MassTransit.IFilter`1[MassTransit.ConsumeContext`1[Tests.SagaStateMachineTests+Start]] CorrelateById(MassTransit.ISagaRepository`1[Tests.SagaStateMachineTests+ConsumerSaga], MassTransit.ISagaPolicy`2[Tests.SagaStateMachineTests+ConsumerSaga,Tests.SagaStateMachineTests+Start], MassTransit.IPipe`1[MassTransit.SagaConsumeContext`2[Tests.SagaStateMachineTests+ConsumerSaga,Tests.SagaStateMachineTests+Start]])
+          },
+          Event: {
+            Name: StartEvent
+          },
+          DataType: SagaStateMachineTests.Start,
+          MessageFilter: {},
+          Policy: {}
+        }
+      ],
+      Accessor: {},
+      Initial: {
+        Name: Initial,
+        Enter: {
+          Name: Initial.Enter
+        },
+        Leave: {
+          Name: Initial.Leave
+        },
+        BeforeEnter: {
+          Name: Initial.BeforeEnter
+        },
+        AfterLeave: {
+          Name: Initial.AfterLeave
+        },
+        Events: [
+          {
+            Name: StartEvent
+          }
+        ]
+      },
+      Final: {
+        Name: Final,
+        Enter: {
+          Name: Final.Enter
+        },
+        Leave: {
+          Name: Final.Leave
+        },
+        BeforeEnter: {
+          Name: Final.BeforeEnter
+        },
+        AfterLeave: {
+          Name: Final.AfterLeave
+        },
+        Events: []
+      },
+      States: [
+        {
+          Name: Initial,
+          Enter: {
+            Name: Initial.Enter
+          },
+          Leave: {
+            Name: Initial.Leave
+          },
+          BeforeEnter: {
+            Name: Initial.BeforeEnter
+          },
+          AfterLeave: {
+            Name: Initial.AfterLeave
+          },
+          Events: [
+            {
+              Name: StartEvent
+            }
+          ]
+        },
+        {
+          Name: Final,
+          Enter: {
+            Name: Final.Enter
+          },
+          Leave: {
+            Name: Final.Leave
+          },
+          BeforeEnter: {
+            Name: Final.BeforeEnter
+          },
+          AfterLeave: {
+            Name: Final.AfterLeave
+          },
+          Events: []
+        },
+        {
+          Name: Started,
+          Enter: {
+            Name: Started.Enter
+          },
+          Leave: {
+            Name: Started.Leave
+          },
+          BeforeEnter: {
+            Name: Started.BeforeEnter
+          },
+          AfterLeave: {
+            Name: Started.AfterLeave
+          },
+          Events: []
+        }
+      ],
+      Events: [
+        {
+          Name: StartEvent
+        }
+      ]
+    }
+  }
+}

--- a/src/Tests/SagaStateMachineTests.cs
+++ b/src/Tests/SagaStateMachineTests.cs
@@ -55,8 +55,6 @@ public class SagaStateMachineTests
         {
             InstanceState(x => x.CurrentState);
 
-            Event(() => StartEvent, x => x.CorrelateById(context => context.Message.CorrelationId));
-
             Initially(
                 When(StartEvent)
                     .Then(context =>

--- a/src/Tests/SagaStateMachineTests.cs
+++ b/src/Tests/SagaStateMachineTests.cs
@@ -1,0 +1,72 @@
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests;
+
+[UsesVerify]
+public class SagaStateMachineTests
+{
+    #region SagaStateMachineTests
+    [Fact]
+    public async Task Run()
+    {
+        // Based on https://masstransit-project.com/usage/testing.html#saga-state-machine
+
+        await using var provider = new ServiceCollection()
+            .AddMassTransitTestHarness(cfg =>
+            {
+                cfg.AddSagaStateMachine<ConsumerStateMachine, ConsumerSaga>();
+            })
+            .BuildServiceProvider(true);
+        var harness = provider.GetRequiredService<ITestHarness>();
+        var sagaHarness = harness.GetSagaStateMachineHarness<ConsumerStateMachine, ConsumerSaga>();
+
+        var correlationId = NewId.NextGuid();
+
+        await harness.Start();
+
+        await harness.Bus.Publish(new Start { CorrelationId = correlationId });
+
+        await Verify(new { harness, sagaHarness })
+            .ScrubLinesContaining("Address: 'loopback://");
+    }
+
+    public class ConsumerSaga : SagaStateMachineInstance
+    {
+        public Guid CorrelationId { get; set; }
+        public string? CurrentState { get; set; }
+
+        public bool StartMessageReceived { get; set; }
+    }
+
+    public class Start : CorrelatedBy<Guid>
+    {
+        public Guid CorrelationId { get; set; }
+    }
+
+    public class ConsumerStateMachine : MassTransitStateMachine<ConsumerSaga>
+    {
+        public Event<Start>? StartEvent { get; set; }
+
+        public State? Started { get; set; }
+
+        public ConsumerStateMachine()
+        {
+            InstanceState(x => x.CurrentState);
+
+            Event(() => StartEvent, x => x.CorrelateById(context => context.Message.CorrelationId));
+
+            Initially(
+                When(StartEvent)
+                    .Then(context =>
+                    {
+                        context.Saga.StartMessageReceived = true;
+                    })
+                    .Finalize());
+
+            SetCompletedWhenFinalized();
+        }
+    }
+    #endregion
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.3.0" PrivateAssets="all" />


### PR DESCRIPTION
Here's an example for verifying a saga state machine.

- Based on the MT docs the way harnesses are created is now through IoC. The old methods will be obsoleted.
- I needed a scrubber to remove the loopback address the bus was using.